### PR TITLE
synchronous STDOUT

### DIFF
--- a/bin/ecs-deploy
+++ b/bin/ecs-deploy
@@ -14,6 +14,7 @@
 #     -w | --wait-time       Time given to wait until all services have the new task definition running
 #     -f | --file            ECS deploy configuration file (default: config/ecs_deploy.yml)
 #
+$stdout.sync = true
 $stderr.sync = true
 require "ecs_deploy"
 


### PR DESCRIPTION
To cope with error messages for taks being shown before their info messages:
<img width="840" alt="image" src="https://user-images.githubusercontent.com/12839/45669749-3e663280-bb21-11e8-9585-b6d812d0d03e.png">
